### PR TITLE
fix(sonar): close last 2 gosecurity:S2083 path-injection findings (2→0)

### DIFF
--- a/schematool/handlers.go
+++ b/schematool/handlers.go
@@ -95,22 +95,19 @@ func writeGeneratedSchemaResponse(w http.ResponseWriter, req SchemaRequest) bool
 var jsonMarshalIndentFn = json.MarshalIndent
 
 func persistSchemaRequest(req SchemaRequest) {
-	// Reject EntityName values that could escape ``SchemaDefinitionsDir``
-	// before constructing the destination path. This closes the
-	// ``gosecurity:S2083`` (path injection from user-controlled data)
-	// surface that previously sat in ``filepath.Join(.., req.EntityName+".json")``.
-	if !isSafeSchemaName(req.EntityName) {
-		log.Printf(
-			"Refusing to persist schema definition with unsafe entity name: %q",
-			req.EntityName,
-		)
-		return
-	}
 	if err := os.MkdirAll(SchemaDefinitionsDir, 0755); err != nil {
 		log.Printf("Error creating schema_definitions directory: %v", err)
 		return
 	}
-	filePath := filepath.Join(SchemaDefinitionsDir, req.EntityName+".json")
+	// safeSchemaPath enforces a Rel-based containment check on top of
+	// isSafeSchemaName so the Sonar taint analyser (gosecurity:S2083)
+	// can prove ``req.EntityName`` cannot escape SchemaDefinitionsDir
+	// before reaching os.WriteFile.
+	filePath, pathErr := safeSchemaPath(SchemaDefinitionsDir, req.EntityName)
+	if pathErr != nil {
+		log.Printf("Refusing to persist schema definition: %v", pathErr)
+		return
+	}
 	fileData, marshalErr := jsonMarshalIndentFn(req, "", "  ")
 	if marshalErr != nil {
 		log.Printf("Error marshalling schema definition for saving: %v", marshalErr)
@@ -168,12 +165,14 @@ func LoadSchemaDefinitionHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Missing 'name' query parameter", http.StatusBadRequest)
 		return
 	}
-	if !isSafeSchemaName(name) {
+	// safeSchemaPath enforces a Rel-based containment check so the Sonar
+	// taint analyser (gosecurity:S2083) can prove ``name`` cannot escape
+	// SchemaDefinitionsDir before reaching os.ReadFile.
+	filePath, pathErr := safeSchemaPath(SchemaDefinitionsDir, name)
+	if pathErr != nil {
 		http.Error(w, "Invalid 'name' query parameter", http.StatusBadRequest)
 		return
 	}
-
-	filePath := filepath.Join(SchemaDefinitionsDir, name+".json")
 	fileData, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -216,4 +215,34 @@ func isSafeSchemaName(name string) bool {
 		return false
 	}
 	return true
+}
+
+// filepathAbsForSchema is the indirection used by safeSchemaPath. Tests
+// can override it to inject filepath.Abs failures (which only occur if
+// os.Getwd fails, which is virtually untestable on real systems).
+var filepathAbsForSchema = filepath.Abs
+
+// safeSchemaPath returns the cleaned absolute path for ``<base>/<name>.json``
+// only when the resolved path stays inside ``base``. Returning an explicit
+// error after a Rel-based containment check is what convinces the Sonar
+// taint analyser (gosecurity:S2083 / CWE-22) that the user-controlled
+// ``name`` cannot reach ``os.WriteFile``/``os.ReadFile``.
+func safeSchemaPath(base, name string) (string, error) {
+	if !isSafeSchemaName(name) {
+		return "", fmt.Errorf("unsafe schema name: %q", name)
+	}
+	candidate := filepath.Join(base, name+".json")
+	cleanedBase, err := filepathAbsForSchema(filepath.Clean(base))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve base path: %w", err)
+	}
+	cleanedCandidate, err := filepathAbsForSchema(filepath.Clean(candidate))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve candidate path: %w", err)
+	}
+	rel, err := filepath.Rel(cleanedBase, cleanedCandidate)
+	if err != nil || strings.HasPrefix(rel, "..") || rel == ".." {
+		return "", fmt.Errorf("schema path escapes base directory: %s", name)
+	}
+	return cleanedCandidate, nil
 }

--- a/schematool/persist_errors_test.go
+++ b/schematool/persist_errors_test.go
@@ -9,6 +9,75 @@ import (
 	"testing"
 )
 
+// TestSafeSchemaPath_AbsBaseError exercises the filepath.Abs failure on
+// the base path (covered via the filepathAbsForSchema indirection).
+func TestSafeSchemaPath_AbsBaseError(t *testing.T) {
+	originalAbs := filepathAbsForSchema
+	defer func() { filepathAbsForSchema = originalAbs }()
+	calls := 0
+	filepathAbsForSchema = func(p string) (string, error) {
+		calls++
+		if calls == 1 {
+			return "", os.ErrInvalid
+		}
+		return originalAbs(p)
+	}
+	if _, err := safeSchemaPath("/tmp/base", "Foo"); err == nil {
+		t.Fatal("expected base resolution error to surface")
+	}
+}
+
+// TestSafeSchemaPath_AbsCandidateError covers the second filepath.Abs
+// failure path (resolving the candidate file).
+func TestSafeSchemaPath_AbsCandidateError(t *testing.T) {
+	originalAbs := filepathAbsForSchema
+	defer func() { filepathAbsForSchema = originalAbs }()
+	calls := 0
+	filepathAbsForSchema = func(p string) (string, error) {
+		calls++
+		if calls == 2 {
+			return "", os.ErrInvalid
+		}
+		return originalAbs(p)
+	}
+	if _, err := safeSchemaPath("/tmp/base", "Foo"); err == nil {
+		t.Fatal("expected candidate resolution error to surface")
+	}
+}
+
+// TestSafeSchemaPath_EscapeDetected forces the Rel-based containment
+// check to fail by returning an absolute candidate that resolves
+// outside the base. We accomplish this by making filepathAbsForSchema
+// rewrite the candidate to a sibling path.
+func TestSafeSchemaPath_EscapeDetected(t *testing.T) {
+	originalAbs := filepathAbsForSchema
+	defer func() { filepathAbsForSchema = originalAbs }()
+	filepathAbsForSchema = func(p string) (string, error) {
+		// Pretend the candidate ended up outside ``/safe/base`` so the
+		// filepath.Rel containment check returns a "..".
+		if filepath.Base(p) == "Foo.json" {
+			return "/elsewhere/Foo.json", nil
+		}
+		return "/safe/base", nil
+	}
+	if _, err := safeSchemaPath("/safe/base", "Foo"); err == nil {
+		t.Fatal("expected escape detection to surface as error")
+	}
+}
+
+// TestSafeSchemaPath_HappyPath drives the success branch so the function
+// reports 100% coverage.
+func TestSafeSchemaPath_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	got, err := safeSchemaPath(dir, "ValidName")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("expected absolute path, got %q", got)
+	}
+}
+
 // TestListSchemaDefinitionsHandler_DirMissing exercises the early-return
 // branch for "schema_definitions directory not yet created" (lines 140-142):
 // the handler responds 200 with an empty JSON list rather than a 500.

--- a/schematool/persist_errors_test.go
+++ b/schematool/persist_errors_test.go
@@ -9,20 +9,30 @@ import (
 	"testing"
 )
 
-// TestSafeSchemaPath_AbsBaseError exercises the filepath.Abs failure on
-// the base path (covered via the filepathAbsForSchema indirection).
-func TestSafeSchemaPath_AbsBaseError(t *testing.T) {
+// runSafeSchemaPathWithFailingAbs runs safeSchemaPath with
+// filepathAbsForSchema patched to fail on the Nth call (1-indexed).
+// Centralising the patching keeps the per-branch tests under qlty's
+// duplication threshold while still asserting each error path.
+func runSafeSchemaPathWithFailingAbs(t *testing.T, failOnCall int) error {
+	t.Helper()
 	originalAbs := filepathAbsForSchema
 	defer func() { filepathAbsForSchema = originalAbs }()
 	calls := 0
 	filepathAbsForSchema = func(p string) (string, error) {
 		calls++
-		if calls == 1 {
+		if calls == failOnCall {
 			return "", os.ErrInvalid
 		}
 		return originalAbs(p)
 	}
-	if _, err := safeSchemaPath("/tmp/base", "Foo"); err == nil {
+	_, err := safeSchemaPath("/tmp/base", "Foo")
+	return err
+}
+
+// TestSafeSchemaPath_AbsBaseError exercises the filepath.Abs failure on
+// the base path (covered via the filepathAbsForSchema indirection).
+func TestSafeSchemaPath_AbsBaseError(t *testing.T) {
+	if err := runSafeSchemaPathWithFailingAbs(t, 1); err == nil {
 		t.Fatal("expected base resolution error to surface")
 	}
 }
@@ -30,17 +40,7 @@ func TestSafeSchemaPath_AbsBaseError(t *testing.T) {
 // TestSafeSchemaPath_AbsCandidateError covers the second filepath.Abs
 // failure path (resolving the candidate file).
 func TestSafeSchemaPath_AbsCandidateError(t *testing.T) {
-	originalAbs := filepathAbsForSchema
-	defer func() { filepathAbsForSchema = originalAbs }()
-	calls := 0
-	filepathAbsForSchema = func(p string) (string, error) {
-		calls++
-		if calls == 2 {
-			return "", os.ErrInvalid
-		}
-		return originalAbs(p)
-	}
-	if _, err := safeSchemaPath("/tmp/base", "Foo"); err == nil {
+	if err := runSafeSchemaPathWithFailingAbs(t, 2); err == nil {
 		t.Fatal("expected candidate resolution error to surface")
 	}
 }


### PR DESCRIPTION
## **User description**
## Summary

Even after PR #20 added the ``isSafeSchemaName`` predicate, Sonar's taint analyser still flagged ``schematool/handlers.go:119`` and ``handlers.go:177`` because it doesn't follow validation predicates back to the source. The user-controlled string still appears to flow into ``filepath.Join`` → ``os.WriteFile``/``os.ReadFile``.

This PR mirrors the ``safeJoinUnderBase`` pattern PR #18 introduced for ``dynamictablefilter/engine.go``: a new ``safeSchemaPath(base, name)`` helper performs a Rel-based containment check (``filepath.Abs`` + ``filepath.Clean`` + ``filepath.Rel`` + ``..`` prefix guard) and returns an explicit error on escape. Both handlers now obtain ``filePath`` from the helper, which is what convinces the analyser the user-controlled name cannot reach ``os.WriteFile``/``os.ReadFile``.

## Tests added
- ``TestSafeSchemaPath_AbsBaseError`` / ``TestSafeSchemaPath_AbsCandidateError`` cover the two ``filepath.Abs`` failure branches via a ``filepathAbsForSchema`` indirection (same pattern engine.go uses).
- ``TestSafeSchemaPath_EscapeDetected`` forces the Rel-based escape check to fail.
- ``TestSafeSchemaPath_HappyPath`` drives the success branch.

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./...`` passing (loghelper, schematool)
- [ ] CI: shared-scanner-matrix / Sonar Zero (expects 0 findings)
- [ ] CI: shared-scanner-matrix / Coverage 100 Gate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the last two `gosecurity:S2083` findings by adding `safeSchemaPath` and enforcing in-base schema paths. Prevents path traversal to `os.WriteFile`/`os.ReadFile`.

- **Bug Fixes**
  - Added `safeSchemaPath(base, name)` to validate `name` and ensure the resolved path stays under `base` (Clean + Abs + Rel check).
  - Switched `persistSchemaRequest` and `LoadSchemaDefinitionHandler` to use `safeSchemaPath`.
  - Added tests for Abs errors, escape detection, and the happy path using `filepathAbsForSchema`.

- **Refactors**
  - Extracted `runSafeSchemaPathWithFailingAbs` to remove duplicated test setup flagged by `qlty`.

<sup>Written for commit 6792742d51e6443b590360d8aaa298647ff2a678. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/DevExtreme-Filter-Go-Language/pull/21?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Prevent schema file paths from escaping the schema definitions folder

### What Changed
- Schema files are now saved and loaded only after an extra path check confirms the final file stays inside the schema definitions folder
- Requests with unsafe schema names now fail with a clear error instead of reaching file read or write operations
- Added tests for path resolution failures, escape detection, and the successful save/load path

### Impact
`✅ Fewer schema path traversal risks`
`✅ Safer schema file reads and saves`
`✅ Clearer invalid-name errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=BpT89uX0mxI6s_K795uELsyJofL9sivgMBr7lAsDO18&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
