### PR TITLE
fix(sonar): wrap pathErr in loghelper.Safe (gosecurity:S5145, last devextreme finding)

### DIFF
--- a/schematool/handlers.go
+++ b/schematool/handlers.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"transaction-filter-backend/loghelper"
 )
 
 // Header / status / content-type literals reused across handlers; pulled to
@@ -105,7 +107,10 @@ func persistSchemaRequest(req SchemaRequest) {
 	// before reaching os.WriteFile.
 	filePath, pathErr := safeSchemaPath(SchemaDefinitionsDir, req.EntityName)
 	if pathErr != nil {
-		log.Printf("Refusing to persist schema definition: %v", pathErr)
+		// loghelper.Safe escapes CR/LF/TAB so the user-controlled
+		// EntityName cannot smuggle a fake log line (Sonar
+		// gosecurity:S5145 / CWE-117 mitigation).
+		log.Printf("Refusing to persist schema definition: %s", loghelper.Safe(pathErr.Error()))
 		return
 	}
 	fileData, marshalErr := jsonMarshalIndentFn(req, "", "  ")


### PR DESCRIPTION
## **User description**
## Summary

The last open Sonar finding on devextreme main was ``gosecurity:S5145`` (CWE-117 log injection) at ``schematool/handlers.go:108``. ``log.Printf(\"...: %v\", pathErr)`` flowed the user-controlled ``req.EntityName`` (wrapped inside ``pathErr.Error()``) into a log line, allowing CRLF smuggling of fake log entries even though ``isSafeSchemaName`` + ``safeSchemaPath`` already blocked path-traversal.

Wrap with ``loghelper.Safe`` — the same helper PR #18 introduced for ``main.go`` / ``main_handlers.go`` — which escapes CR/LF/TAB before emission.

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./schematool/...`` passing
- [ ] CI: shared-scanner-matrix / Sonar Zero (expects 0 findings — devextreme reaches strict-zero on Sonar with this merge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized logging in `schematool/handlers.go` by wrapping `pathErr.Error()` with `loghelper.Safe` to escape CR/LF/TAB and prevent log injection (`gosecurity:S5145`, CWE-117). Removes the final Sonar finding by blocking fake log lines from user-controlled input.

<sup>Written for commit a7cfbeea28539a85c4d7e8bd09a3780a71a8a7d7. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/DevExtreme-Filter-Go-Language/pull/22?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Sanitize schema save error logs to block fake log entries**

### What Changed
- Error messages shown when a schema name is rejected are now cleaned before being written to logs
- This prevents user-provided schema names from inserting line breaks or fake log lines into server logs

### Impact
`✅ Safer error logs`
`✅ Fewer log injection risks`
`✅ Clearer audit trails`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=MJ5S60I0V2usIMi4XkLDMpnFseVPnt1ZpFntL_pBRck&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
