### PR TITLE
fix(security): sanitize log inputs via loghelper.Safe (CWE-117)

### DIFF
--- a/schematool/handlers.go
+++ b/schematool/handlers.go
@@ -46,7 +46,7 @@ func decodeSchemaRequest(w http.ResponseWriter, r *http.Request) (SchemaRequest,
 	var req SchemaRequest
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&req); err != nil {
-		log.Printf("Error decoding /generate-schema-code request: %v", err)
+		log.Printf("Error decoding /generate-schema-code request: %s", loghelper.Safe(err.Error()))
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return SchemaRequest{}, false
 	}
@@ -65,13 +65,13 @@ func writeGeneratedSchemaResponse(w http.ResponseWriter, req SchemaRequest) bool
 	log.Printf("Received /generate-schema-code request in schematool")
 	goCode, err := GenerateGoSchemaCode(req)
 	if err != nil {
-		log.Printf("Error generating Go schema code: %v", err)
+		log.Printf("Error generating Go schema code: %s", loghelper.Safe(err.Error()))
 		http.Error(w, fmt.Sprintf("Error generating schema code: %v", err), http.StatusInternalServerError)
 		return false
 	}
 	adapterCode, err := generateGoAdapterCodeFn(req)
 	if err != nil {
-		log.Printf("Error generating Go adapter code: %v", err)
+		log.Printf("Error generating Go adapter code: %s", loghelper.Safe(err.Error()))
 		http.Error(w, fmt.Sprintf("Error generating adapter code: %v", err), http.StatusInternalServerError)
 		return false
 	}
@@ -81,7 +81,7 @@ func writeGeneratedSchemaResponse(w http.ResponseWriter, req SchemaRequest) bool
 	}
 	w.Header().Set(headerContentType, mimeApplicationJSON)
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
-		log.Printf("Error encoding schema/adapter code response: %v", err)
+		log.Printf("Error encoding schema/adapter code response: %s", loghelper.Safe(err.Error()))
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return false
 	}
@@ -98,7 +98,7 @@ var jsonMarshalIndentFn = json.MarshalIndent
 
 func persistSchemaRequest(req SchemaRequest) {
 	if err := os.MkdirAll(SchemaDefinitionsDir, 0755); err != nil {
-		log.Printf("Error creating schema_definitions directory: %v", err)
+		log.Printf("Error creating schema_definitions directory: %s", loghelper.Safe(err.Error()))
 		return
 	}
 	// safeSchemaPath enforces a Rel-based containment check on top of
@@ -115,11 +115,11 @@ func persistSchemaRequest(req SchemaRequest) {
 	}
 	fileData, marshalErr := jsonMarshalIndentFn(req, "", "  ")
 	if marshalErr != nil {
-		log.Printf("Error marshalling schema definition for saving: %v", marshalErr)
+		log.Printf("Error marshalling schema definition for saving: %s", loghelper.Safe(marshalErr.Error()))
 		return
 	}
 	if err := os.WriteFile(filePath, fileData, 0644); err != nil {
-		log.Printf("Error writing schema definition file %q: %v", filePath, err)
+		log.Printf("Error writing schema definition file %q: %s", filePath, loghelper.Safe(err.Error()))
 	} else {
 		log.Printf("Saved schema definition to %q", filePath)
 	}
@@ -139,7 +139,7 @@ func ListSchemaDefinitionsHandler(w http.ResponseWriter, r *http.Request) {
 			json.NewEncoder(w).Encode([]string{})
 			return
 		}
-		log.Printf("Error reading schema_definitions directory: %v", err)
+		log.Printf("Error reading schema_definitions directory: %s", loghelper.Safe(err.Error()))
 		http.Error(w, "Failed to list schema definitions", http.StatusInternalServerError)
 		return
 	}
@@ -153,7 +153,7 @@ func ListSchemaDefinitionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(headerContentType, mimeApplicationJSON)
 	if err := json.NewEncoder(w).Encode(definitionNames); err != nil {
-		log.Printf("Error encoding definition names: %v", err)
+		log.Printf("Error encoding definition names: %s", loghelper.Safe(err.Error()))
 		http.Error(w, "Failed to encode definition names", http.StatusInternalServerError)
 	}
 }
@@ -183,7 +183,7 @@ func LoadSchemaDefinitionHandler(w http.ResponseWriter, r *http.Request) {
 		if os.IsNotExist(err) {
 			http.Error(w, "Schema definition not found", http.StatusNotFound)
 		} else {
-			log.Printf("Error reading schema definition file %q: %v", filePath, err)
+			log.Printf("Error reading schema definition file %q: %s", filePath, loghelper.Safe(err.Error()))
 			http.Error(w, "Failed to read schema definition", http.StatusInternalServerError)
 		}
 		return
@@ -191,7 +191,7 @@ func LoadSchemaDefinitionHandler(w http.ResponseWriter, r *http.Request) {
 
 	var schemaReq SchemaRequest
 	if err := json.Unmarshal(fileData, &schemaReq); err != nil {
-		log.Printf("Error unmarshalling schema definition file %q: %v", filePath, err)
+		log.Printf("Error unmarshalling schema definition file %q: %s", filePath, loghelper.Safe(err.Error()))
 		http.Error(w, "Invalid schema definition file format", http.StatusInternalServerError)
 		return
 	}
@@ -202,7 +202,7 @@ func LoadSchemaDefinitionHandler(w http.ResponseWriter, r *http.Request) {
 	// our schema, regardless of what's on disk.
 	w.Header().Set(headerContentType, mimeApplicationJSON)
 	if err := json.NewEncoder(w).Encode(schemaReq); err != nil {
-		log.Printf("Error writing schema definition response: %v", err)
+		log.Printf("Error writing schema definition response: %s", loghelper.Safe(err.Error()))
 	}
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Resolves CodeQL go/log-injection alerts in schematool/handlers.go by applying the existing \`loghelper.Safe\` sanitizer to 12 \`log.Printf(\"Error ...: %v\", err)\` sites.

Pattern:
\`\`\`go
log.Printf(\"Error ...: %v\", err)            // before
log.Printf(\"Error ...: %s\", loghelper.Safe(err.Error()))  // after
\`\`\`

The \`loghelper.Safe\` helper replaces \`\n\`, \`\r\`, \`\t\` with visible escape sequences so a malicious actor can't forge log entries by embedding control characters in their input (CWE-117).

## Sites Fixed

- \`decodeSchemaRequest\` (1)
- \`writeGeneratedSchemaResponse\` (2)
- \`writeJSONResponse\` (1)
- \`persistSchemaRequest\` (3)
- \`ListDefinitionsHandler\` (2)
- \`LoadDefinitionHandler\` (3)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./schematool/...\` — all pass
- [ ] CodeQL re-run on PR closes the 6 alerts on schematool/handlers.go

## After this lands

DevExtreme CodeQL: 24 → 18 (closes 6 schematool/handlers.go alerts). The remaining 18 on main.go / generic_ent_adapter.go / dynamictablefilter/engine.go are likely stale (per the line-number drift discovered earlier — these files don't have current \`log.Printf %v\` patterns).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized error strings in `schematool/handlers.go` using `loghelper.Safe` to prevent log injection (CWE-117). Resolves the CodeQL go/log-injection alerts for this file.

- **Bug Fixes**
  - Replaced 12 instances of `log.Printf("...: %v", err)` with `log.Printf("...: %s", loghelper.Safe(err.Error()))`.
  - Affects: `decodeSchemaRequest`, `writeGeneratedSchemaResponse`, `persistSchemaRequest`, `ListSchemaDefinitionsHandler`, `LoadSchemaDefinitionHandler`.
  - Blocks control characters from forging log lines; expected to clear 6 CodeQL alerts on this file.

<sup>Written for commit a0409b9710429d7ee56b365ca077ae4946b16008. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/DevExtreme-Filter-Go-Language/pull/27?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Prevent forged log entries from user-controlled error text**

### What Changed
- Error messages written to logs are now cleaned before being recorded, so newline, carriage return, and tab characters cannot split or fake log lines
- This protection now covers schema code generation, schema saving, schema listing, and schema loading failures
- User-facing error responses stay the same, but the logged details are safer to inspect

### Impact
`✅ Fewer forged log entries`
`✅ Safer error logs`
`✅ Cleaner incident investigation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Y2Pr_f79NvCt3-0nT33HmNo6lL37rEpX4TaG9Jp_7gA&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
