### PR TITLE
fix(security): sanitize http.Error and fmt.Errorf user-input wrapping

### DIFF
--- a/generic_ent_adapter.go
+++ b/generic_ent_adapter.go
@@ -10,6 +10,7 @@ import (
 	"time" // Needed for timeOperatorHandlers
 
 	"transaction-filter-backend/dynamictablefilter"
+	"transaction-filter-backend/loghelper"
 	"transaction-filter-backend/schematool"
 
 	"entgo.io/ent/dialect/sql"
@@ -101,7 +102,7 @@ func (ga *GenericEntAdapter) GetPredicateForField(field string, op string, val i
 	columnName := strings.ToLower(field)
 	fieldSchema, ok := ga.tableSchema.FieldMap[columnName]
 	if !ok {
-		return nil, fmt.Errorf("field '%s' not found in schema for entity '%s'", field, ga.entityName)
+		return nil, fmt.Errorf("field '%s' not found in schema for entity '%s'", loghelper.Safe(field), loghelper.Safe(ga.entityName))
 	}
 	opLower := strings.ToLower(op)
 	if opLower == "between" {

--- a/schematool/handlers.go
+++ b/schematool/handlers.go
@@ -66,13 +66,13 @@ func writeGeneratedSchemaResponse(w http.ResponseWriter, req SchemaRequest) bool
 	goCode, err := GenerateGoSchemaCode(req)
 	if err != nil {
 		log.Printf("Error generating Go schema code: %s", loghelper.Safe(err.Error()))
-		http.Error(w, fmt.Sprintf("Error generating schema code: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Error generating schema code: %s", loghelper.Safe(err.Error())), http.StatusInternalServerError)
 		return false
 	}
 	adapterCode, err := generateGoAdapterCodeFn(req)
 	if err != nil {
 		log.Printf("Error generating Go adapter code: %s", loghelper.Safe(err.Error()))
-		http.Error(w, fmt.Sprintf("Error generating adapter code: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Error generating adapter code: %s", loghelper.Safe(err.Error())), http.StatusInternalServerError)
 		return false
 	}
 	payload := map[string]string{


### PR DESCRIPTION
## **User description**
## Summary

Followup to PR #27. CodeQL post-#27 reanalysis still flagged 3 real sites where user-controlled data flowed into HTTP response or wrapped errors without sanitization.

## Sites Fixed

**schematool/handlers.go:**
- Line 69, 75: \`http.Error(w, fmt.Sprintf(\"...%v\", err))\` → \`...%s\", loghelper.Safe(err.Error())\`
- Sanitizes error message before sending to HTTP response (CWE-117 if logged downstream)

**generic_ent_adapter.go:**
- Line 105: \`fmt.Errorf(\"field '%s' ...\", field, ga.entityName)\` → wrap both with \`loghelper.Safe\`
- Adds \`transaction-filter-backend/loghelper\` import
- Prevents CR/LF injection from malicious filter request

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./schematool/... ./loghelper/...\` passes
- [ ] CodeQL alerts #21, #6 close on next scan

## After this lands

DevExtreme CodeQL: 6 → ~3 (closes the 3 genuinely real findings; remaining are likely stale main.go alerts at line 151 \`return fmt.Errorf(...%w, err)\` which CodeQL may auto-close once it sees the upstream sanitization paths).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized user-controlled error messages in `schematool` and `generic_ent_adapter` to prevent injection in HTTP responses and logs. Closes the remaining go/log-injection paths and hardens error handling.

- **Bug Fixes**
  - `schematool/handlers.go`: use `%s` with `loghelper.Safe(err.Error())` in `http.Error`.
  - `generic_ent_adapter.go`: wrap `field` and `ga.entityName` with `loghelper.Safe` in `fmt.Errorf(...)`.
  - Add `transaction-filter-backend/loghelper` import.

<sup>Written for commit 8393a4f1e46dd73a7c2eb061416476580a8c6ebd. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/DevExtreme-Filter-Go-Language/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Sanitize user-provided values before returning error messages**

### What Changed
- Error responses from schema generation now remove unsafe user input before sending the message back to the browser
- Errors for unknown fields now keep the field name and entity name from being treated as raw input in wrapped error messages

### Impact
`✅ Safer error responses`
`✅ Fewer injection risks in logs`
`✅ Clearer security scan results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5AE3mjGIn-mn3y-7zI9vftWXHvEEatPL-1hjLMVjdr4&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Error messages for entity field lookup operations are now properly sanitized.
* Error responses returned to clients when schema generation and code generation failures occur are now properly sanitized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->