### PR TITLE
DO NOT MERGE: A/B control - reusable-quality pin stays @v1

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,3 +1,4 @@
+# DO NOT MERGE - evidence branch for the quality-zero-platform v1 tag-move decision (paired A/B; sibling branch differs only in the reusable pin).
 # Lean 6-gate quality (thin caller).
 #
 # Delegates to the shared reusable lean-gate workflow in


### PR DESCRIPTION
DO NOT MERGE: A/B control arm (pin stays @v1)

Evidence artifact for the "is it safe to move the v1 tag in
quality-zero-platform" decision. This branch changes NOTHING behavioural: it
adds one comment line to .github/workflows/quality.yml so a PR can exist, and
KEEPS the reusable-quality.yml pin at @v1.

Its sibling probe branch carries the identical comment line plus the single
pin change @v1 -> @main, so the two runs differ by exactly one variable.

Not for merge. Close when the tag decision is recorded.
