### PR TITLE
fix(deps): bump golang.org/x/text 0.21.0 -> 0.39.0 (GO-2026-5970)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module transaction-filter-backend
 
-go 1.25.11
+go 1.25.12
 
 require (
 	entgo.io/ent v0.14.6

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/zclconf/go-cty v1.14.4 // indirect
 	github.com/zclconf/go-cty-yaml v1.1.0 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,10 @@ github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-yaml v1.1.0 h1:nP+jp0qPHv2IhUVqmQSzjvqAWcObN0KBkUl2rWBdig0=
 github.com/zclconf/go-cty-yaml v1.1.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
-golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
-golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
-golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
-golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
fix(deps): bump golang.org/x/text 0.21.0 -> 0.39.0 (GO-2026-5970)

golang.org/x/text: infinite loop on invalid input -- a norm.Iter can enter an
infinite loop on input containing invalid UTF-8 bytes (CVE-2026-56852, HIGH).

Floor: the advisory has a single range [0, 0.39.0), so the applicable fix (the
range the resolved version sits in) and the forward floor (max fixed across all
ranges) are both 0.39.0. Resolved version was read from go.mod, not go.sum --
go.sum lists every version MVS considered and is not a resolved set.

golang.org/x/mod moves 0.24.0 -> 0.37.0 as well. That is MVS necessity, not
scope creep: x/text v0.39.0 requires x/mod v0.37.0. OSV reports zero
vulnerabilities for both new versions.

Reachability -- this is a real, reachable finding, not a phantom:
- the advisory names import path golang.org/x/text/unicode/norm;
- `go mod why -m golang.org/x/text` gives a real chain:
  transaction-filter-backend/ent/enttest -> entgo.io/ent/dialect/sql/schema ->
  ariga.io/atlas/sql/mysql -> github.com/zclconf/go-cty/cty -> x/text/unicode/norm;
- `go list -deps ./...` independently confirms x/text/unicode/norm and
  x/text/transform are in the build import graph.
(Note: `go mod why` WITHOUT -m reports "main module does not need package
golang.org/x/text" -- that is a detector artifact, because the module root has
no importable package. Only the -m form and go list answer the module question.)

Verification (local; scripts/verify runs `go test ./...` + `go vet ./...`):
- per-test failure sets are IDENTICAL base vs head: 2 failures on both sides,
  376 passing on both sides, per-package collected counts identical, no tests
  lost. The 2 failures are pre-existing and Windows-only (pathsafe.TestContain
  compares backslash-separated paths against forward-slash expectations); they
  are unrelated to this change and are expected to pass on Linux CI.
- `go vet ./...`: clean, exit 0.
