### PR TITLE
fix(sast): scan the 49 unscanned *_test.go files + catch SQL injection through a local

### DIFF
--- a/.quality/opengrep/go-security.yml
+++ b/.quality/opengrep/go-security.yml
@@ -15,6 +15,62 @@ rules:
           - pattern: $DB.Exec(fmt.Sprintf(...), ...)
           - pattern: $DB.ExecContext($CTX, fmt.Sprintf(...), ...)
 
+  # ── DATAFLOW companion to go-sql-string-concat. That rule (and every other
+  # rule in this file) matches SYNTAX: it requires the INLINE form
+  # `db.Query(fmt.Sprintf(...))`. Measured 2026-08-11 on the pinned CI engine
+  # (opengrep v1.22.0 CLI on Linux) with this exact ruleset:
+  #
+  #   src/inline.go   db.Query(fmt.Sprintf(...))                    FIRES
+  #   src/viavar.go   q := fmt.Sprintf(...); db.Query(q)            SILENT
+  #
+  # The second file WAS scanned (`paths.scanned` contains it), so this is a
+  # rule-precision gap, not a targeting artifact -- and the two-statement form
+  # is arguably the MORE idiomatic Go. That makes a clean zero from a
+  # syntax-only set much weaker evidence than it looks, which is the reason this
+  # rule exists.
+  #
+  # Both-states corpus for THIS rule, all on opengrep v1.22.0:
+  #   BAD   q := fmt.Sprintf(...) -> db.Query(q)            FIRES
+  #   BAD   base := fmt.Sprintf(...); q := base -> Query(q) FIRES  (two hops)
+  #   BAD   same shape inside a *_test.go file              FIRES  (needs the
+  #                                                         .semgrepignore too)
+  #   GOOD  db.Query("... $1", name)   (parameterized)      silent
+  #   GOOD  fmt.Sprintf(...) -> Fprintln (no SQL sink)      silent
+  #   GOOD  q := fmt.Sprintf("SELECT count(*) FROM users")  silent (constant-
+  #                                                         only format string)
+  - id: go-sql-format-taint
+    languages: [go]
+    severity: WARNING
+    mode: taint
+    message: >-
+      Possible SQL injection: a formatted/concatenated string flows into a SQL
+      query API. This rule follows DATAFLOW, so unlike go-sql-string-concat it
+      also catches the two-statement form (`q := fmt.Sprintf(...)` then
+      `db.Query(q)`). Use parameterized queries or a query builder (e.g. ent
+      predicates) instead.
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: fmt.Sprintf(...)
+              - pattern: fmt.Sprint(...)
+              - pattern: fmt.Sprintln(...)
+          # A format call with only a constant format string and no arguments is
+          # still a constant, not attacker-influenced data.
+          - pattern-not: fmt.Sprintf("...")
+          - pattern-not: fmt.Sprint("...")
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $DB.Query($Q, ...)
+              - pattern: $DB.QueryContext($CTX, $Q, ...)
+              - pattern: $DB.QueryRow($Q, ...)
+              - pattern: $DB.QueryRowContext($CTX, $Q, ...)
+              - pattern: $DB.Exec($Q, ...)
+              - pattern: $DB.ExecContext($CTX, $Q, ...)
+              - pattern: $DB.Prepare($Q, ...)
+              - pattern: $DB.PrepareContext($CTX, $Q, ...)
+          - focus-metavariable: $Q
+
   - id: go-exec-command-with-variable
     languages: [go]
     severity: WARNING

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,57 @@
+# opengrep / semgrep ignore — gate 4 (SAST). Adopted from
+# quality-zero-platform docs/lean-gate/semgrepignore.template.
+#
+# ── WHY THIS FILE IS LOAD-BEARING HERE IN PARTICULAR ────────────────────────
+#
+# With NO `.semgrepignore` in the scanned root, opengrep falls back to a
+# BUILT-IN ignore template that drops `*_test.go` AT ANY DEPTH. Measured
+# 2026-08-11 on the pinned CI engine (opengrep v1.22.0 CLI on Linux, the exact
+# build reusable-quality.yml installs), controlled detector, one variable at a
+# time:
+#
+#   src/inline.go    db.Query(fmt.Sprintf(...))        -> FIRES
+#   tests/inline.go  byte-identical to the line above  -> SILENT
+#
+# and `paths.skipped` reported `none` while it happened, so nothing in the gate
+# output revealed it. This repo is the worst case in the fleet: it follows Go's
+# own `foo_test.go` convention, so ALL 49 of its test files were dropped no
+# matter where they sit. Gate 4 scanned 60 files; with this file it scans 109.
+# Layout does not help — `dynamictablefilter/engine_filter_test.go` was skipped
+# exactly like the root-level ones.
+#
+# For contrast, the template does NOT drop Python/TS test filenames
+# (`test_app.py`, `app.test.ts`, `app.spec.ts`, `__tests__/`) — only `*_test.go`
+# plus the `test/` and `tests/` directories. Go repos are uniquely exposed.
+#
+# ── EDITING RULES ───────────────────────────────────────────────────────────
+#
+# 1. NEVER add `*_test.go`, `test/`, `tests/` or `spec/`. First-party test code
+#    is first-party code, and re-excluding it restores the exact hole this file
+#    closes.
+# 2. `ent/` is deliberately NOT excluded. It is generated code, but scanning it
+#    was measured to produce ZERO findings, so there is nothing to buy by
+#    hiding it. (The narrower `paths: exclude` on `go-weak-rand-for-security` in
+#    .quality/opengrep/go-security.yml stays as-is: that is one rule's scope,
+#    not a repo-wide blind spot.)
+# 3. Every directory entry ships BOTH the root-anchored and the nested form: a
+#    bare `**/x/` does NOT match a root-level `x/`, and it fails open with no
+#    warning.
+# 4. An exclusion is a statement about SCOPE ("this is not our source"), never
+#    about severity. Do not use this file to make a finding go away.
+
+.git/
+
+# Vendored third-party source, should any be added. Secrets in such trees stay
+# covered by gitleaks (gate 5), which scans independently of this file.
+vendor/
+**/vendor/
+node_modules/
+**/node_modules/
+
+# Build output, generated from source gate 4 already scans.
+dist/
+**/dist/
+build/
+**/build/
+out/
+**/out/


### PR DESCRIPTION
## What this is

Gate 4 (SAST) has **never looked at this repository's tests**, and its SQL rule only matches one of the two ways to write the bug. Both settled by experiment on the **pinned CI engine** — opengrep v1.22.0 CLI on Linux, exactly the build `reusable-quality.yml:399` installs — with a controlled detector and one variable changed at a time. Confidence: almost certain (90-99%).

No tag is moved. `quality.yml` here pins `reusable-quality.yml@v1` and that pin is untouched, so this takes effect on the next gate run with no tag or ruleset movement.

---

## 1. All 49 `*_test.go` files were silently unscanned

With no `.semgrepignore` in the scanned root, opengrep falls back to a built-in ignore template that drops `*_test.go` **at any depth**:

| file | content | result |
|---|---|---|
| `src/inline.go` | `db.Query(fmt.Sprintf(...))` | **FIRES** `go-sql-string-concat` |
| `tests/inline.go` | byte-identical to the file above | **SILENT** |

`paths.skipped` reported **`none`** while it happened, so nothing in the gate output revealed it. Pointing the scanner *directly* at a test path returns `paths.scanned: []`, so an explicit path argument does not override it either.

**This repo is the fleet's worst case**, because it follows Go's own `foo_test.go` convention, so layout does not help — `dynamictablefilter/engine_filter_test.go` was dropped exactly like the root-level ones. For contrast, the template does **not** drop Python/TS test filenames (`test_app.py`, `app_test.py`, `conftest.py`, `app.test.ts`, `app.spec.ts`, `__tests__/`); only `*_test.go` plus the `test/` and `tests/` directories. Go repos are uniquely exposed, which is why `STRATEGY.md` §1a already flagged this repo.

Shipping `.semgrepignore` fixes it because the engine drops the built-in template as soon as any such file exists:

| | before | after |
|---|---|---|
| files scanned | 60 | **109** |
| `*_test.go` scanned | 0 | **49** |
| `ent/` scanned | 44 | 44 |
| findings | 0 | **0** |

`ent/` is **deliberately not excluded** — scanning its 44 generated files produces zero findings, so there is nothing to buy by hiding it. The narrower `paths: exclude: [ent/, vendor/]` on `go-weak-rand-for-security` stays exactly as it was: that is one rule's scope, not a repo-wide blind spot.

---

## 2. The SQL rule matched syntax, not dataflow

`go-sql-string-concat` requires the **inline** form. The identical vulnerability written as two statements escaped **all four** rules:

| file | shape | result |
|---|---|---|
| `src/inline.go` | `db.Query(fmt.Sprintf(...))` | **FIRES** |
| `src/viavar.go` | `q := fmt.Sprintf(...)` then `db.Query(q)` | **SILENT** |

The second file **was** scanned (`paths.scanned` contains it), so this is a rule-precision gap and not a targeting artifact — and the two-statement form is arguably the *more* idiomatic Go. That materially weakens the earlier conclusion that "0 findings is the correct answer for those rules": correct, but the rules were narrow in a way that made the zero much weaker evidence than it looked.

Adds `go-sql-format-taint` (`mode: taint`), which follows the value instead of the shape, over `Query` / `QueryContext` / `QueryRow` / `QueryRowContext` / `Exec` / `ExecContext` / `Prepare` / `PrepareContext`.

---

## Both-states proof — run against the ruleset and `.semgrepignore` as committed here

| corpus file | shape | verdict |
|---|---|---|
| `bad_viavar.go` | `q := fmt.Sprintf(...)` → `db.Query(q)` | **FIRES** |
| `bad_twohop.go` | `base := fmt.Sprintf(...)`; `q := base` → `db.QueryContext(q)` | **FIRES** |
| `bad_intest_test.go` | same shape **inside a `*_test.go`** | **FIRES** |
| `good_param.go` | `db.Query("… $1", name)` | silent |
| `good_nosink.go` | `fmt.Sprintf(...)` → `Fprintln` (no SQL sink) | silent |
| `good_constfmt.go` | `q := fmt.Sprintf("SELECT count(*) FROM users")` | silent |

```
gate exit, known-BAD file present    : 1     <- non-zero, as required
gate exit, known-GOOD files only     : 0
control, .semgrepignore removed      : *_test.go scanned = False
                                       paths.skipped     = none
```

`bad_intest_test.go` is the case that proves the two fixes **compose**: the taint rule alone would still never see it, because the file itself was invisible. The removed-`.semgrepignore` control is the both-states half — a probe that is silent in the broken state measures nothing, so the hole is demonstrated, not asserted.

## Real repository, exact CI invocation

```
opengrep scan --config .quality/opengrep --error \
  --exclude .venv --exclude node_modules --exclude dist --exclude out --exclude build .

Ran 5 rules on 109 files: 0 findings.
gate exit 0
109 scanned  =  49 *_test.go  +  44 ent/  +  16 other
```

**0 findings, and no exclusion was added anywhere to reach that zero.** So the gate stays green while now actually inspecting 49 files and one more vulnerability shape than it did before.

## Related

Control-plane companion — the copyable template plus a non-blocking gate-4 warning for any caller with no explicit scan set: Prekzursil/quality-zero-platform#289. Nine other public repos ship `.quality/opengrep` without a `.semgrepignore` and get the same treatment in their own PRs.
